### PR TITLE
Use SendGrid API Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ LOG_LEVEL=debug
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 # WEBHOOK_PROXY_URL=
+
+# Go to https://app.sendgrid.com/settings/api_keys to create a SendGrid API key, make sure you provide Mail Send access
+SENDGRID_APIKEY=

--- a/lib/email.js
+++ b/lib/email.js
@@ -67,11 +67,11 @@ function commitText (commit) {
   Author: ${commitAuthor}
   Date:   ${commit.timestamp} (${strftime('%a, %d %b %Y', new Date(commit.timestamp))})`
 
-  if (changedPaths.size > 0) {
+  if (changedPaths.length > 0) {
     text += `
-      Changed paths:
-        ${changedPaths}
-    `
+
+  Changed paths:
+    ${changedPaths}`
   }
 
   text += `

--- a/lib/email.js
+++ b/lib/email.js
@@ -6,8 +6,7 @@ const process = require('process')
 async function sendEmail (addresses, payload) {
   let options = {
     auth: {
-      api_user: process.env.SENDGRID_USERNAME,
-      api_key: process.env.SENDGRID_PASSWORD
+      api_key: process.env.SENDGRID_APIKEY
     }
   }
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -29,13 +29,17 @@ async function sendEmail (addresses, payload) {
     body += `Compare: ${payload.compare}\n`
   }
 
+  // Strip leading whitespaces from body
+  body = body.replace(/^ {2}/gm, '')
+
   addresses.forEach((address) => {
     // Message object
     let message = {
       from: 'Probot Messenger <probot-messenger@no-reply.com>',
       to: address,
       subject: subject,
-      text: body.replace(/^ {2}/gm, '')
+      text: body,
+      html: `<pre>${body}</pre>`
     }
 
     client.sendMail(message, (err, info) => {

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -75,6 +75,9 @@ describe('probot-messenger', () => {
         Author: baxterthehacker <baxterthehacker@users.noreply.github.com>
         Date:   2015-05-05T19:40:15-04:00 (Tue, 05 May 2015)
 
+        Changed paths:
+          M README.md
+
         Log Message:
         -----------
         Update README.md

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -89,6 +89,7 @@ describe('probot-messenger', () => {
       expect(request.to).toEqual(argumentToMock.to)
       expect(request.subject).toEqual(argumentToMock.subject)
       expect(request.text).toEqual(argumentToMock.text)
+      expect(`<pre>${request.text}</pre>`).toEqual(argumentToMock.html)
     })
   })
 })


### PR DESCRIPTION
Adds a new environment variable, `SENDGRID_APIKEY` and removes password, following SendGrid's [Node.js example](https://app.sendgrid.com/guide/integrate/langs/nodejs).

Also adds an explicit HTML representation of the email message, just by wrapping the plain text version with `pre` tags.

Also fixes a minor bug that was preventing `Changed paths` being included in the sent email.