### PR TITLE
Configurable sender

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = (robot) => {
   robot.on('push', async context => {
     const config = await getConfig(context, 'probot-messenger.yml')
     let addresses = []
+    let sender = {
+      name: 'Probot Messenger',
+      address: 'probot-messenger@no-reply.com'
+    }
 
     config.services.forEach((el) => {
       if (el.name === 'email') {
@@ -13,7 +17,7 @@ module.exports = (robot) => {
     })
 
     if (addresses.length !== 0) {
-      sendEmail(addresses, context.payload)
+      sendEmail(sender, addresses, context.payload)
     }
   })
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = (robot) => {
     config.services.forEach((el) => {
       if (el.name === 'email') {
         addresses = el.addresses
+        // Override sender, if provided
+        sender = el.sender || sender
       }
     })
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -3,7 +3,7 @@ const nodemailer = require('nodemailer')
 const sgTransport = require('nodemailer-sendgrid-transport')
 const process = require('process')
 
-async function sendEmail (addresses, payload) {
+async function sendEmail (sender, addresses, payload) {
   let options = {
     auth: {
       api_user: process.env.SENDGRID_USERNAME,
@@ -33,7 +33,7 @@ async function sendEmail (addresses, payload) {
   addresses.forEach((address) => {
     // Message object
     let message = {
-      from: 'Probot Messenger <probot-messenger@no-reply.com>',
+      from: `${sender.name} <${sender.address}>`,
       to: address,
       subject: subject,
       text: body.replace(/^ {2}/gm, '')

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -93,7 +93,7 @@ describe('probot-messenger', () => {
       expect(request.text).toEqual(argumentToMock.text)
     })
 
-    it ('sends an email with a custom sender', async () => {
+    it('sends an email with a custom sender', async () => {
       config += `
         sender:
           name: Name

--- a/test/email.test.js
+++ b/test/email.test.js
@@ -25,8 +25,18 @@ function fixture (name, path) {
 describe('probot-messenger', () => {
   let robot
   let github
+  let config
 
   beforeEach(() => {
+    config = `
+    services:
+      -
+        name: email
+        addresses:
+          - hubot@users.noreply.github.com
+          - octocat@users.noreply.github.com
+    `
+
     sendEmailMock.mockClear()
 
     // Here we create a robot instance
@@ -36,16 +46,9 @@ describe('probot-messenger', () => {
   })
 
   describe('sending email', () => {
-    beforeEach(() => {
-      const config = `
-      services:
-        -
-          name: email
-          addresses:
-            - hubot@users.noreply.github.com
-            - octocat@users.noreply.github.com
-      `
+    const payload = fixture('push', './fixtures/push.json')
 
+    beforeEach(() => {
       github = {
         repos: {
           getContent: jest.fn().mockImplementation(() => Promise.resolve({
@@ -60,7 +63,6 @@ describe('probot-messenger', () => {
     })
 
     it('sends an email when receiving a push payload', async () => {
-      const payload = fixture('push', './fixtures/push.json')
       // Simulates delivery of a payload
       await robot.receive(payload)
 
@@ -89,6 +91,20 @@ describe('probot-messenger', () => {
       expect(request.to).toEqual(argumentToMock.to)
       expect(request.subject).toEqual(argumentToMock.subject)
       expect(request.text).toEqual(argumentToMock.text)
+    })
+
+    it ('sends an email with a custom sender', async () => {
+      config += `
+        sender:
+          name: Name
+          address: name@example.com
+      `
+
+      // Simulates delivery of a payload
+      await robot.receive(payload)
+      expect(sendEmailMock).toHaveBeenCalled()
+      const argumentToMock = sendEmailMock.mock.calls[0][0]
+      expect('Name <name@example.com>').toEqual(argumentToMock.from)
     })
   })
 })


### PR DESCRIPTION
Allows the sender of the email to be configured via `sender` property of `probot-messenger.yml`, e.g.

```yaml
---
services:
- name: email
  addresses:
  - to@example.com
  sender:
    name: From
    address: from@example.com
```

I think this should help with messages not being detected as spam.