### PR TITLE
Fix heroku deployment configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   "addons": [
     {
       "plan": "sendgrid:starter",
-      "as": "SendGrid"
+      "as": "SENDGRID"
     }
   ],
   "env": {


### PR DESCRIPTION
Heroku provisioning fails due to SendGrid missmatch. The current Heroku deployment returns an error `sendgrid add-ons can only be attached as SENDGRID.`.

fixes https://github.com/gjtorikian/probot-emailer/issues/8